### PR TITLE
[PD-4723] add required import for reduce

### DIFF
--- a/fsm/views.py
+++ b/fsm/views.py
@@ -1,5 +1,6 @@
 import json
 import operator
+from functools import reduce
 
 from django.db.models import Q
 from django.http import HttpResponse


### PR DESCRIPTION
some admin views are failing because of this deprecated usage of reduce. This import works for both py 2 and 3. 

* need to update requirements in MyJobs with new hash